### PR TITLE
Looks in Principal Request Context for MFA Context Request

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ gradleVersion=4.5
 
 version=3.2.4
 
-casClientVersion=3.5.0
+casClientVersion=3.5.1
 commonLangVersion=2.5
 junitVersion=4.12
 mockitoVersion=1.9.5

--- a/src/main/java/net/unicon/idp/authn/provider/extra/EntityIdParameterBuilder.java
+++ b/src/main/java/net/unicon/idp/authn/provider/extra/EntityIdParameterBuilder.java
@@ -17,7 +17,7 @@ public class EntityIdParameterBuilder implements IParameterBuilder {
     private final Logger logger = LoggerFactory.getLogger(EntityIdParameterBuilder.class);
 
     @Override
-    public String getParameterString(final HttpServletRequest request) {
+    public String getParameterString(final HttpServletRequest request, final String authenticationKey) {
         return getParameterString(request, true);
     }
 

--- a/src/main/java/net/unicon/idp/authn/provider/extra/IParameterBuilder.java
+++ b/src/main/java/net/unicon/idp/authn/provider/extra/IParameterBuilder.java
@@ -15,5 +15,5 @@ public interface IParameterBuilder {
      * @param request The original request.
      * @return a string of the form: paramName=value
      */
-    String getParameterString(HttpServletRequest request);
+    String getParameterString(HttpServletRequest request, String authenticationKey);
 }

--- a/src/main/java/net/unicon/idp/externalauth/ShibcasAuthServlet.java
+++ b/src/main/java/net/unicon/idp/externalauth/ShibcasAuthServlet.java
@@ -71,7 +71,7 @@ public class ShibcasAuthServlet extends HttpServlet {
 
             if ((ticket == null || ticket.isEmpty()) && (gatewayAttempted == null || gatewayAttempted.isEmpty())) {
                 logger.debug("ticket and gatewayAttempted are not set; initiating CAS login redirect");
-                startLoginRequest(request, response, force, passive);
+                startLoginRequest(request, response, force, passive, authenticationKey);
                 return;
             }
 
@@ -114,7 +114,8 @@ public class ShibcasAuthServlet extends HttpServlet {
         ExternalAuthentication.finishExternalAuthentication(authenticationKey, request, response);
     }
 
-    protected void startLoginRequest(final HttpServletRequest request, final HttpServletResponse response, final Boolean force, final Boolean passive) {
+    protected void startLoginRequest(final HttpServletRequest request, final HttpServletResponse response,
+                                     final Boolean force, final Boolean passive, String authenticationKey) {
         // CAS Protocol - http://www.jasig.org/cas/protocol indicates not setting gateway if renew has been set.
         // we will set both and let CAS sort it out, but log a warning
         if (Boolean.TRUE.equals(passive) && Boolean.TRUE.equals(force)) {
@@ -127,7 +128,7 @@ public class ShibcasAuthServlet extends HttpServlet {
                 serviceUrl += "&gatewayAttempted=true";
             }
 
-            final String loginUrl = constructRedirectUrl(serviceUrl, force, passive) + getAdditionalParameters(request);
+            final String loginUrl = constructRedirectUrl(serviceUrl, force, passive) + getAdditionalParameters(request, authenticationKey);
             logger.debug("loginUrl: {}", loginUrl);
             response.sendRedirect(loginUrl);
         } catch (final IOException e) {
@@ -148,10 +149,10 @@ public class ShibcasAuthServlet extends HttpServlet {
      * @param request The original servlet request
      * @return an ampersand delimited list of querystring parameters
      */
-    private String getAdditionalParameters(final HttpServletRequest request) {
+    private String getAdditionalParameters(final HttpServletRequest request, final String authenticationKey) {
         final StringBuilder builder = new StringBuilder();
         for (final IParameterBuilder paramBuilder : parameterBuilders) {
-            builder.append(paramBuilder.getParameterString(request));
+            builder.append(paramBuilder.getParameterString(request, authenticationKey));
         }
         return builder.toString();
     }

--- a/src/test/java/net/unicon/idp/externalauth/ShibcasAuthServletTest.java
+++ b/src/test/java/net/unicon/idp/externalauth/ShibcasAuthServletTest.java
@@ -254,7 +254,7 @@ public class ShibcasAuthServletTest {
         final ShibcasAuthServlet shibcasAuthServlet = new ShibcasAuthServlet();
         shibcasAuthServlet.init(createMockServletConfig());
 
-        shibcasAuthServlet.startLoginRequest(request, response, false, false);
+        shibcasAuthServlet.startLoginRequest(request, response, false, false, "");
         verify(response).sendRedirect("https://cassserver.example.edu/cas/login?service=https%3A%2F%2Fshibserver.example.edu%2Fidp%2FAuthn%2FExtCas%3Fconversation%3De1s1&entityId=http%3A%2F%2Ftest.edu%2Fsp");
     }
 
@@ -269,7 +269,7 @@ public class ShibcasAuthServletTest {
         final ShibcasAuthServlet shibcasAuthServlet = new ShibcasAuthServlet();
         shibcasAuthServlet.init(createMockServletConfig("embed"));
 
-        shibcasAuthServlet.startLoginRequest(request, response, false, false);
+        shibcasAuthServlet.startLoginRequest(request, response, false, false, "");
         verify(response).sendRedirect("https://cassserver.example.edu/cas/login?service=https%3A%2F%2Fshibserver.example.edu%2Fidp%2FAuthn%2FExtCas%3Fconversation%3De1s1%26entityId%3Dhttp%3A%2F%2Ftest.edu%2Fsp");
     }
 
@@ -284,7 +284,7 @@ public class ShibcasAuthServletTest {
         final ShibcasAuthServlet shibcasAuthServlet = new ShibcasAuthServlet();
         shibcasAuthServlet.init(createMockServletConfig("append"));
 
-        shibcasAuthServlet.startLoginRequest(request, response, false, false);
+        shibcasAuthServlet.startLoginRequest(request, response, false, false, "");
         verify(response).sendRedirect("https://cassserver.example.edu/cas/login?service=https%3A%2F%2Fshibserver.example.edu%2Fidp%2FAuthn%2FExtCas%3Fconversation%3De1s1&entityId=http%3A%2F%2Ftest.edu%2Fsp");
     }
 
@@ -300,7 +300,7 @@ public class ShibcasAuthServletTest {
         shibcasAuthServlet.init(createMockServletConfig());
 
         //Passive
-        shibcasAuthServlet.startLoginRequest(request, response, false, true);
+        shibcasAuthServlet.startLoginRequest(request, response, false, true, "");
         verify(response).sendRedirect("https://cassserver.example.edu/cas/login?service=https%3A%2F%2Fshibserver.example.edu%2Fidp%2FAuthn%2FExtCas%3Fconversation%3De1s1%26gatewayAttempted%3Dtrue&gateway=true&entityId=http%3A%2F%2Ftest.edu%2Fsp");
     }
 
@@ -316,7 +316,7 @@ public class ShibcasAuthServletTest {
         shibcasAuthServlet.init(createMockServletConfig());
 
         //Forced
-        shibcasAuthServlet.startLoginRequest(request, response, true, false);
+        shibcasAuthServlet.startLoginRequest(request, response, true, false, "");
         verify(response).sendRedirect("https://cassserver.example.edu/cas/login?service=https%3A%2F%2Fshibserver.example.edu%2Fidp%2FAuthn%2FExtCas%3Fconversation%3De1s1&renew=true&entityId=http%3A%2F%2Ftest.edu%2Fsp");
        }
 
@@ -332,7 +332,7 @@ public class ShibcasAuthServletTest {
         shibcasAuthServlet.init(createMockServletConfig());
 
         //Passive and Forced
-        shibcasAuthServlet.startLoginRequest(request, response, true, true);
+        shibcasAuthServlet.startLoginRequest(request, response, true, true, "");
         verify(response).sendRedirect("https://cassserver.example.edu/cas/login?service=https%3A%2F%2Fshibserver.example.edu%2Fidp%2FAuthn%2FExtCas%3Fconversation%3De1s1%26gatewayAttempted%3Dtrue&renew=true&gateway=true&entityId=http%3A%2F%2Ftest.edu%2Fsp");
     }
 


### PR DESCRIPTION
Changes Authn Parameter builder to not use the deprecated AUTHN_METHOD attribute and instead inspects the PrincipalRequestContext to determine the requested principals.