### PR TITLE
CAS backward compatibility patch

### DIFF
--- a/src/main/java/net/unicon/idp/externalauth/ShibcasAuthServlet.java
+++ b/src/main/java/net/unicon/idp/externalauth/ShibcasAuthServlet.java
@@ -140,7 +140,7 @@ public class ShibcasAuthServlet extends HttpServlet {
      * Uses the CAS CommonUtils to build the CAS Redirect URL.
      */
     private String constructRedirectUrl(final String serviceUrl, final boolean renew, final boolean gateway) {
-        return CommonUtils.constructRedirectUrl(casLoginUrl, "service", serviceUrl, renew, gateway, null);
+        return CommonUtils.constructRedirectUrl(casLoginUrl, "service", serviceUrl, renew, gateway);
     }
 
     /**

--- a/src/main/java/net/unicon/idp/externalauth/ShibcasAuthServlet.java
+++ b/src/main/java/net/unicon/idp/externalauth/ShibcasAuthServlet.java
@@ -258,13 +258,13 @@ public class ShibcasAuthServlet extends HttpServlet {
      * Use the CAS CommonUtils to build the CAS Service URL.
      */
     protected String constructServiceUrl(final HttpServletRequest request, final HttpServletResponse response) {
-        String serviceUrl = CommonUtils.constructServiceUrl(request, response, null, serverName,
-            serviceParameterName, artifactParameterName, true);
+        String serviceUrl = CommonUtils.constructServiceUrl(request, response, null, serverName, serviceParameterName, artifactParameterName, false);
 
         if ("embed".equalsIgnoreCase(entityIdLocation)) {
             serviceUrl += (new EntityIdParameterBuilder().getParameterString(request, false));
         }
 
+        logger.debug("constructServiceUrl: " + serviceUrl);
 
         return serviceUrl;
     }
@@ -277,7 +277,7 @@ public class ShibcasAuthServlet extends HttpServlet {
      */
     protected String constructServiceUrl(final HttpServletRequest request, final HttpServletResponse response, final boolean isValidatingTicket) {
         return isValidatingTicket
-            ? CommonUtils.constructServiceUrl(request, response, null, serverName, serviceParameterName, artifactParameterName, true)
+            ? CommonUtils.constructServiceUrl(request, response, null, serverName, serviceParameterName, artifactParameterName, false)
             : constructServiceUrl(request, response);
     }
 

--- a/src/test/java/net/unicon/idp/externalauth/ShibcasAuthServletTest.java
+++ b/src/test/java/net/unicon/idp/externalauth/ShibcasAuthServletTest.java
@@ -239,7 +239,7 @@ public class ShibcasAuthServletTest {
 
         final String result = shibcasAuthServlet.constructServiceUrl(request, response, true);
 
-        assertEquals("https://shibserver.example.edu/idp/Authn/ExtCas?conversation=e1s1&entityId=http%3A%2F%2Ftest.edu%2Fsp", result);
+        assertEquals("https://shibserver.example.edu/idp/Authn/ExtCas?conversation=e1s1&entityId=http://test.edu/sp", result);
     }
 
 


### PR DESCRIPTION
No re-encoding of ':' and '/' of entityId parameters when ShibCAS constructs the CAS service url ; backward compatibility with old CAS servers because they can't validate ST tickets when the encoding changes.

For example, [https://idp.example/idp/Authn/External?conversation=e1s1&entityId=https://sp.example] does not match supplied service [https://idp.example/idp/Authn/External?conversation=e1s1&entityId=https%3A%2F%2Fsp.example]